### PR TITLE
Fix lint warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR "${workdir}"
 
 HEALTHCHECK --interval=10s --start-period=90s CMD netstat -ltn | grep -c ":443"
 
-ENV EXPIRATION_DAYS 30
+ENV EXPIRATION_DAYS=30
 
 ##
 #  Drupal
@@ -23,9 +23,9 @@ FROM base AS drupal
 
 COPY /drupal /
 
-ENV NGINX_FASTCGI_PASS_HOST php
-ENV NGINX_FASTCGI_PASS_PORT 9000
-ENV NGINX_CLIENT_MAX_BODY_SIZE 128M
+ENV NGINX_FASTCGI_PASS_HOST=php
+ENV NGINX_FASTCGI_PASS_PORT=9000
+ENV NGINX_CLIENT_MAX_BODY_SIZE=128M
 
 ##
 #  Proxy
@@ -41,7 +41,7 @@ FROM proxy AS nextjs
 
 COPY /nextjs /
 
-ENV NGINX_PROXY_PASS http://app:3000
+ENV NGINX_PROXY_PASS=http://app:3000
 
 ##
 #  Storybook
@@ -50,5 +50,5 @@ FROM proxy AS storybook
 
 COPY /storybook /
 
-ENV NGINX_PROXY_PASS http://app:6006
-ENV SERVER_CHANNEL_PROXY_PASS ws://app:6006/storybook-server-channel
+ENV NGINX_PROXY_PASS=http://app:6006
+ENV SERVER_CHANNEL_PROXY_PASS=ws://app:6006/storybook-server-channel


### PR DESCRIPTION
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
