### PR TITLE
Improve mac user documentation

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,3 @@
+---
+MD013:
+  code_blocks: false

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ volumes:
 
 > [!TIP]
 >
-> Mac users should then do (one time only):
+> Mac users should do the following (one time only) while no
+> containers are running:
 >
 > ```console
-> mkdir -p ~/.local/share && ln -s "$(mkcert -CAROOT)" ~/.local/share`
+> mkdir -p ~/.local/share && find ~/.local/share -name mkcert -type d -delete && ln -s "$(mkcert -CAROOT)" ~/.local/share`
 > ```
 >
 > If you haven't installed mkcert yet, you can do so with Homebrew:


### PR DESCRIPTION
- Make sure no containers are running while doing the one-time setup.

- Make sure a stray `mkcert` folder is deleted if one was created during previous runs