### PR TITLE
Increase proxy buffer sizes

### DIFF
--- a/context/proxy/etc/nginx/templates/default.conf.template
+++ b/context/proxy/etc/nginx/templates/default.conf.template
@@ -9,5 +9,10 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Increase buffer sizes, the defaults can be too tight for
+        # modern applications.
+        proxy_buffer_size 16k;
+        proxy_buffers 4 16k;
+        proxy_busy_buffers_size 32k;
     }
 }


### PR DESCRIPTION
Things like cache tag headers can be a bit too large for the NginX default buffers.